### PR TITLE
Adding Jenkins Server & Build Server setup scripts

### DIFF
--- a/setup_build_server.sh
+++ b/setup_build_server.sh
@@ -1,0 +1,26 @@
+#Install git
+sudo yum install git -y
+git --version
+
+#Install docker
+sudo yum install docker -y
+sudo systemctl start docker
+sudo systemctl status docker
+sudo systemctl enable docker
+docker version
+
+#Install Terraform
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
+sudo yum -y install terraform
+terraform -version
+
+#Install go
+sudo yum install -y golang
+go version
+
+#Install AWS CLI
+sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+sudo unzip awscliv2.zip
+sudo ./aws/install
+aws --version

--- a/setup_jenkins_server.sh
+++ b/setup_jenkins_server.sh
@@ -1,0 +1,10 @@
+#Install Jenkins
+sudo amazon-linux-extras install epel -y
+sudo yum update -y
+sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+sudo yum install jenkins java-1.8.0-openjdk-devel -y
+sudo systemctl start jenkins
+systemctl status jenkins
+sudo systemctl enable jenkins
+
+#Setup Jenkins server's further steps as per https://linuxize.com/post/how-to-install-jenkins-on-centos-7/#setting-up-jenkins


### PR DESCRIPTION
### Description

Created Jenkins Server & Build Server Shell Scripts.

Pre-requisite is to have a VM running from AWS. In this example I have used EC2 machine whose port 8080 is open so that Jenkins Server UI can be accessible. 

[setup_jenkins_server.sh](https://github.com/sarangrana/TechChallengeApp/blob/feature/create-jenkins-and-build-server/setup_jenkins_server.sh) script will install jenkins and few more steps to be followed as per [https://linuxize.com/post/how-to-install-jenkins-on-centos-7/#setting-up-jenkins](https://linuxize.com/post/how-to-install-jenkins-on-centos-7/#setting-up-jenkins)

### Checklist

- [x] Code compiles correctly
- [x] Installing all required packages
- [x] Starting the services for the current session
- [x] Services are started even after reboot
